### PR TITLE
Update returnofdiagnol.py

### DIFF
--- a/returnofdiagnol.py
+++ b/returnofdiagnol.py
@@ -1,9 +1,9 @@
+import numpy as np
 def get_diagonal(matrix):
     if not matrix:
         return []
 
-    num_rows = len(matrix)
-    num_cols = len(matrix[0])
+    num_rows, num_cols = np.shape(matrix)
 
     if num_rows != num_cols:
         raise ValueError("Input matrix must be square.")


### PR DESCRIPTION
Your code calculates the number of columns by only considering the first row of the matrix. This is fine if you have the assumption that all rows have the same number of columns. However, to avoid this assumption, we can use numpy.shape() I have implemented that change for you